### PR TITLE
Work around Foundry's handling of default icons for actors and items

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -69,6 +69,10 @@ class DCCActorSheet extends ActorSheet {
     data.labels = this.actor.labels || {}
     data.filters = this._filters
 
+    if (!data.actor.img || data.actor.img === 'icons/svg/mystery-man.svg') {
+      data.actor.img = EntityImages.imageForActor(data.type)
+    }
+
     if (data.isNPC) {
       this.options.template = 'systems/dcc/templates/actor-sheet-npc.html'
     } else {
@@ -132,6 +136,11 @@ class DCCActorSheet extends ActorSheet {
       if (removeEmptyItems && i.data.quantity !== undefined && i.data.quantity <= 0) {
         this.actor.deleteOwnedItem(i._id, {})
         continue
+      }
+
+      // Fix the icon for items Foundry created with no icon or the mystery-man icon
+      if (!i.img || i.img === 'icons/svg/mystery-man.svg') {
+        i.img = EntityImages.imageForItem(i.type)
       }
 
       if (i.type === 'weapon') {

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -1,6 +1,7 @@
 /* global Dialog, ItemSheet, game, mergeObject, CONFIG */
 
 import DCCItemConfig from './item-config.js'
+import EntityImages from './entity-images.js'
 
 /**
  * Extend the basic ItemSheet for DCC RPG
@@ -53,6 +54,10 @@ export class DCCItemSheet extends ItemSheet {
       data.allowResolve = data.unresolved && !!this.actor && !this.limited
       // Only allow currency conversion on items representing coins that have a resolved value
       data.allowConversions = data.item.data.isCoins && !data.unresolved && !this.limited
+    }
+
+    if (!data.item.img || data.item.img === 'icons/svg/mystery-man.svg') {
+      data.item.img = EntityImages.imageForItem(data.item.type)
     }
 
     return data


### PR DESCRIPTION
Set anything with a null image or mystery man image to our default icon for the actor/item type.